### PR TITLE
Fix login failure when linking anonymous account

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -210,15 +210,18 @@ export function useAuth(): UseAuthReturn {
 
           // Fallback to standard OAuth flow which will create/sign into existing account
           console.log("Using merge strategy - will transfer data to existing Google account");
-          
+
           try {
+            // Sign out first so OAuth signs into the existing account instead of linking
+            await supabase.auth.signOut();
+
             const oauthResult = await supabase.auth.signInWithOAuth({
               provider: "google",
               options: {
                 redirectTo: `${window.location.origin}/auth/callback`,
               },
             });
-            
+
             // OAuth initiated successfully
             return oauthResult;
           } catch (oauthError) {


### PR DESCRIPTION
## Summary
- Ensure anonymous session is signed out before starting OAuth when merge strategy is needed
- Allows login to existing account and triggers image migration

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae85296ec48321b444929d263feed6